### PR TITLE
Associative options for a select

### DIFF
--- a/lib/PhpReports/Report.php
+++ b/lib/PhpReports/Report.php
@@ -305,9 +305,10 @@ class Report {
 					
 					foreach($params['options'] as $key=>$option) {
 						if(!is_array($option)) {
+							is_numeric($key) ? $val = $option : $val = $key;
 							$params['options'][$key] = array(
 								'display'=>$option,
-								'value'=>$option
+								'value'=>$val
 							);
 						}
 						if($params['options'][$key]['value'] == $params['value']) $params['options'][$key]['selected'] = true;


### PR DESCRIPTION
Now we can pass an object to options if we would like a display value mapped to a database value for selects.

Example:

``` json
VARIABLE: {
    "name": "var",
    "display": "Enum",
    "type": "select",
    "multiple": true,
    "options": {
        "DB": "Database", "KEY": "Value", "DBVAL": "Display Val"
     }
}
```
