### PR TITLE
Fix bug with charts.  

### DIFF
--- a/classes/headers/ChartHeader.php
+++ b/classes/headers/ChartHeader.php
@@ -323,6 +323,8 @@ class ChartHeader extends HeaderBase {
 			}
 			else {
 				$rows = $report->options['Rows'];
+
+				if(!$params['columns']) $params['columns'] = range(1,count($rows[0]['values']));
 			}
 			
 			self::getRowInfo($rows, $params, $num, $report);


### PR DESCRIPTION
If no 'columns' parameter is passed, it should default to all the columns in order like it says in the documentation.  It was throwing an error instead.
