### PR TITLE
Dynamic headers

### DIFF
--- a/classes/headers/FormattingHeader.php
+++ b/classes/headers/FormattingHeader.php
@@ -34,20 +34,12 @@ class FormattingHeader extends HeaderBase {
 		'dataset'=>array(
 			'required'=>true,
 			'default'=>true
-		),
-		'has_charts'=>array(
-			'type'=>'boolean'
 		)
 	);
 	
 	public static function init($params, &$report) {
 		if(!isset($report->options['Formatting'])) $report->options['Formatting'] = array();
 		$report->options['Formatting'][] = $params;
-
-		if(isset($params['has_charts']) && $params['has_charts']) {
-			$report->options['has_charts'] = true;
-			if(!isset($report->options['Charts'])) $report->options['Charts'] = array();
-		}
 	}
 	
 	public static function parseShortcut($value) {

--- a/classes/headers/OptionsHeader.php
+++ b/classes/headers/OptionsHeader.php
@@ -69,6 +69,9 @@ class OptionsHeader extends HeaderBase {
 		'default_dataset'=>array(
 			'type'=>'number',
 			'default'=>0
+		),
+		'has_charts'=>array(
+			'type'=>'boolean'
 		)
 	);
 	
@@ -77,6 +80,10 @@ class OptionsHeader extends HeaderBase {
 		if(isset($params['ttl'])) {
 			$params['cache'] = $params['ttl'];
 			unset($params['ttl']);
+		}
+
+		if(isset($params['has_charts']) && $params['has_charts']) {
+			if(!isset($report->options['Charts'])) $report->options['Charts'] = array();
 		}
 		
 		// Some parameters were moved to a 'FORMATTING' header

--- a/lib/PhpReports/Report.php
+++ b/lib/PhpReports/Report.php
@@ -220,9 +220,10 @@ class Report {
 		if(!isset($this->options['Name'])) $this->options['Name'] = $this->report;
 	}
 	
-	public function parseHeader($name,$value) {
+	public function parseHeader($name,$value,$dataset=null) {
 		$classname = $name.'Header';
 		if(class_exists($classname)) {
+			if($dataset !== null && isset($classname::$validation) && isset($classname::$validation['dataset'])) $value['dataset'] = $dataset;
 			$classname::parse($name,$value,$this);
 			if(!in_array($name,$this->headers)) $this->headers[] = $name;
 		}
@@ -421,7 +422,7 @@ class Report {
 			if(isset($dataset['headers'])) {
 				foreach($dataset['headers'] as $j=>$header) {
 					if(isset($header['header']) && isset($header['value'])) {
-						$this->parseHeader($header['header'],$header['value']);
+						$this->parseHeader($header['header'],$header['value'],$i);
 					}
 				}
 			}


### PR DESCRIPTION
Add ability to dynamically add headers from a MongoDB or PHP Report when using datasets.  Here's an example:

``` js
printjson([
  {
    title: "Dataset 1",
    headers: [
      {
        header: "Chart",
        value: {

        }
      }
    ],
    rows: [

    ]
  }
]);
```

For headers that are dataset aware (Formatting, Chart, Rollup, etc.), the `dataset` property is automatically set before parsing the header.

Charts only work when the `has_charts` option is set on the report.  This option loads the required Google libraries. When using normal Chart headers, this option is set automatically, but when you use dynamic headers, you have to set it manually since the report needs to know before it runs.

``` js
// OPTIONS: {has_charts: true}
```
