### PR TITLE
Fixing error when calling a non-existent dashboard

### DIFF
--- a/lib/PhpReports/PhpReports.php
+++ b/lib/PhpReports/PhpReports.php
@@ -268,7 +268,7 @@ class PhpReports {
 	public static function getDashboard($dashboard) {
 		$file = PhpReports::$config['dashboardDir'].'/'.$dashboard.'.json';
 		if(!file_exists($file)) {
-			throw "Unknown dashboard - ".$dashboard;
+			throw new Exception("Unknown dashboard - ".$dashboard);
 		}
 		
 		return json_decode(file_get_contents($file),true);


### PR DESCRIPTION
The `file_exists` check for a dashboard was attempting to throw a string as an error.  This PR uses an exception to avoid the fatal error generated.
