### PR TITLE
Fixing date range Variable Header when passed through a FilterHeader

### DIFF
--- a/lib/PhpReports/PhpReports.php
+++ b/lib/PhpReports/PhpReports.php
@@ -268,7 +268,7 @@ class PhpReports {
 	public static function getDashboard($dashboard) {
 		$file = PhpReports::$config['dashboardDir'].'/'.$dashboard.'.json';
 		if(!file_exists($file)) {
-			throw new Exception("Unknown dashboard - ".$dashboard);
+			throw "Unknown dashboard - ".$dashboard;
 		}
 		
 		return json_decode(file_get_contents($file),true);


### PR DESCRIPTION
When using a FilterHeader, the date range selected for the current report is not correctly passed through to the next report.

This PR uses the numeric indexes for the daterange macro values so they can be passed through to the report specified in the FilterHeader.
