### PR TITLE
Adding order to database_options for MySQL report types

### DIFF
--- a/classes/report_types/MysqlReportType.php
+++ b/classes/report_types/MysqlReportType.php
@@ -91,6 +91,10 @@ class MysqlReportType extends ReportTypeBase {
 		if(isset($params['where'])) {
 			$query .= ' WHERE '.$params['where'];
 		}
+
+		if(isset($params['order']) && in_array($params['order'], array('ASC', 'DESC')) ) {
+			$query .= ' ORDER BY '.$params['column'].' '.$params['order'];
+		}
 		
 		$result = mysql_query($query, $report->conn);
 		


### PR DESCRIPTION
This PR adds the ability to order the results of a database query for a VariableHeader.

Adding an `order` key to the `database_options` object on a VariableHeader will sort the database options before creating the drilldown.  Accepted keys for `order` are `ASC` or `DESC`.

I wasn't sure how this would play with AdoDb, so I didn't modify that report type, but I imagine it would work just fine with a similar update.
