### PR TITLE
ADO reports / use proper sql escape function according to database vendor

### DIFF
--- a/classes/report_types/AdoPivotReportType.php
+++ b/classes/report_types/AdoPivotReportType.php
@@ -62,12 +62,12 @@ class AdoPivotReportType extends ReportTypeBase {
         foreach($macros as $key=>$value) {
             if(is_array($value)) {
                 foreach($value as $key2=>$value2) {
-                    $value[$key2] = mysql_real_escape_string(trim($value2));
+                    $value[$key2] = AdoReportType::sql_escape_string($report,trim($value2));
                 }
                 $macros[$key] = $value;
             }
             else {
-                $macros[$key] = mysql_real_escape_string($value);
+                $macros[$key] = AdoReportType::sql_escape_string($report,$value);
             }
 
             if($value === 'ALL') $macros[$key.'_all'] = true;
@@ -109,13 +109,13 @@ class AdoPivotReportType extends ReportTypeBase {
 			if(is_array($value)) {
 				$first = true;
 				foreach($value as $key2=>$value2) {
-					$value[$key2] = mysql_real_escape_string(trim($value2));
+					$value[$key2] = AdoReportType::sql_escape_string($report,trim($value2));
 					$first = false;
 				}
 				$macros[$key] = $value;
 			}
 			else {
-				$macros[$key] = mysql_real_escape_string($value);
+				$macros[$key] = AdoReportType::sql_escape_string($report,$value);
 			}
 			
 			if($value === 'ALL') $macros[$key.'_all'] = true;

--- a/classes/report_types/AdoReportType.php
+++ b/classes/report_types/AdoReportType.php
@@ -107,13 +107,13 @@ class AdoReportType extends ReportTypeBase {
 			if(is_array($value)) {
 				$first = true;
 				foreach($value as $key2=>$value2) {
-					$value[$key2] = mysql_real_escape_string(trim($value2));
+					$value[$key2] = AdoReportType::sql_escape_string($report,trim($value2));
 					$first = false;
 				}
 				$macros[$key] = $value;
 			}
 			else {
-				$macros[$key] = mysql_real_escape_string($value);
+				$macros[$key] = AdoReportType::sql_escape_string($report,$value);
 			}
 			
 			if($value === 'ALL') $macros[$key.'_all'] = true;
@@ -153,4 +153,12 @@ class AdoReportType extends ReportTypeBase {
 		
 		return $result->GetArray();
 	}
+
+    public static function sql_escape_string(&$report,&$value) {
+        $uri = PhpReports::$config['environments'][$report->options['Environment']]['ado']['uri'];
+        if(preg_match('/^postgres:/',$uri)) {
+            return pg_escape_string($value);
+        }
+        return mysql_real_escape_string($value);
+    }
 }


### PR DESCRIPTION
- ADO reports were always using `mysql_real_escape_string` function which made macro values empty for other databases like postgresql
- Current suggested implementation: if dsn uri starts with 'postgres' then use pg_escape_string function - use mysql_real_escape_string function otherwise

There must be a better way to fix it though but the idea is to be able to use any database vendor (not only MySQL) with ADO connections.
