### PR TITLE
Multi url

### DIFF
--- a/lib/PhpReports/PhpReports.php
+++ b/lib/PhpReports/PhpReports.php
@@ -352,13 +352,18 @@ class PhpReports {
 	}
 
 	protected static function getReportHeaders($report) {
-		$cacheKey = FileSystemCache::generateCacheKey($report,'report_headers');
+		$cacheKey = FileSystemCache::generateCacheKey(array(self::$request->base, $report),'report_headers');
 
 		//check if report data is cached and newer than when the report file was created
 		//the url parameter ?nocache will bypass this and not use cache
 		$data =false;
+
+		$loc = Report::getFileLocation($report);
+		if(!file_exists($loc)) {
+			return false;
+		}
 		if(!isset($_REQUEST['nocache'])) {
-			$data = FileSystemCache::retrieve($cacheKey, filemtime(Report::getFileLocation($report)));
+			$data = FileSystemCache::retrieve($cacheKey, filemtime($loc));
 		}
 
 		//report data not cached, need to parse it

--- a/lib/PhpReports/PhpReports.php
+++ b/lib/PhpReports/PhpReports.php
@@ -356,6 +356,7 @@ class PhpReports {
 
 		//check if report data is cached and newer than when the report file was created
 		//the url parameter ?nocache will bypass this and not use cache
+
 		$data =false;
 
 		$loc = Report::getFileLocation($report);


### PR DESCRIPTION
Allowing reports to work with multiple urls or ports pointing to the same docroot. Added the url base to the cache key for the headers so it won't pull cached data with the wrong urls. Also fixed edge case with a 500 error that happens when you move a report, but it still exists in the recently run.