### PR TITLE
Permit display, value in the select database_options

### DIFF
--- a/classes/report_types/MysqlReportType.php
+++ b/classes/report_types/MysqlReportType.php
@@ -112,7 +112,7 @@ class MysqlReportType extends ReportTypeBase {
 		if(isset($params['all'])) $options[] = 'ALL';
 		
 		while($row = mysql_fetch_assoc($result)) {
-			$options[] = $row[$params['column']];
+			$options[] = $row;
 		}
 		
 		return $options;


### PR DESCRIPTION
One could set the select to be:
```javascript
database_options: {
    table: "(select field_key as value, field_human as display from some_table where 1)",
    column: "display, value"
}
```