### PR TITLE
Fix standard deviation calculation and optionally use stats_standard_deviation function

### DIFF
--- a/classes/headers/RollupHeader.php
+++ b/classes/headers/RollupHeader.php
@@ -89,8 +89,14 @@ class RollupHeader extends HeaderBase {
 				}
 				
 				$devs = array();
-				foreach($real_values as $v) $devs[] = pow($v - $params['mean'], 2);
-				$params['stdev'] = sqrt(array_sum($devs) / (count($devs) - 1));
+				if (empty($real_values)) {
+					$params['stdev'] = 0;
+				} else 	if (function_exists('stats_standard_deviation')) {
+					$params['stdev'] = stats_standard_deviation($real_values);
+				} else {
+					foreach($real_values as $v) $devs[] = pow($v - $params['mean'], 2);
+					$params['stdev'] = sqrt(array_sum($devs) / (count($devs)));
+				}
 			}
 		}
 		


### PR DESCRIPTION
The existing standard deviation function does a -1 on the items count which results in an incorrect value.

Code testing with an expected result of 147.32277488562
<?php

// pecl_stats extenstion.
$stdev = array(600 , 470 , 170 , 430 , 300);
echo stats_standard_deviation($stdev);
echo "\n";

// Code from php-reports.
$real_values = $stdev;
$params = array();
$params['count'] = count($real_values);
$params['sum'] = array_sum($real_values);
if($params['count']) {
    $params['mean'] = $params['average'] = $params['sum'] / $params['count'];
}
foreach($real_values as $v) $devs[] = pow($v - $params['mean'], 2);
echo sqrt(array_sum($devs) / (count($devs)));
echo "\n";